### PR TITLE
Added admin prop to user

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11124,6 +11124,15 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-draggable": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+      "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
+      "requires": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "react-chartjs-2": "^4.0.0",
     "react-country-flag": "^3.0.2",
     "react-dom": "^17.0.2",
+    "react-draggable": "^4.4.4",
     "react-leaflet": "^3.2.4",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,8 +9,12 @@ import Login from './pages/Login';
 import Register from './pages/Register';
 import { AuthProvider } from './context/auth'
 import AuthRoute from './util/AuthRoute'
+import DataRoute from './util/DataRoute'
+import AdminRoute from './util/AdminRoute'
+
 import Country from './pages/Country';
 import Continent from './pages/Continent';
+import Admin from './pages/Admin';
 
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
@@ -40,11 +44,21 @@ function App() {
               </AuthRoute>}>
             </Route>
             <Route exact path="/country" element={
-              <Country />
+              <DataRoute>
+                <Country />
+              </DataRoute>
             }>
             </Route>
             <Route exact path="/continent" element={
-              <Continent />
+              <DataRoute>
+                <Continent />
+              </DataRoute>
+            }>
+            </Route>
+            <Route exact path="/admin" element={
+              <AdminRoute>
+                <Admin />
+              </AdminRoute>
             }>
             </Route>
           </Routes>

--- a/client/src/components/DeleteButton.js
+++ b/client/src/components/DeleteButton.js
@@ -1,0 +1,165 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useMutation } from '@apollo/react-hooks';
+import DeleteIcon from '@mui/icons-material/Delete';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Draggable from 'react-draggable';
+
+function PaperComponent(props) {
+    return (
+        <Draggable
+            handle="#draggable-dialog-title"
+            cancel={'[class*="MuiDialogContent-root"]'}
+        >
+            <Paper {...props} />
+        </Draggable>
+    );
+}
+
+
+function DeleteButton({ selectedCountryId, selectedContinentId, callBack }) {
+    const [open, setOpen] = React.useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const [deleteCountry] = useMutation(DELETE_COUNTRY_MUTATION, {
+        variables: { countryId: selectedCountryId },
+        update(proxy) {
+            if (selectedCountryId) {
+                const data = proxy.readQuery({
+                    query: GET_COUNTRIES
+                });
+                data.getCountries = data.getCountries.filter(country => country.id !== selectedCountryId)
+                proxy.writeQuery({
+                    query: GET_COUNTRIES,
+                    data
+                })
+            }
+            if (callBack) {
+                callBack()
+            }
+        },
+        onError(err) {
+            console.log(err)
+        }
+    })
+
+    const [deleteContinent] = useMutation(DELETE_COTINENT_MUTATION, {
+        variables: { continentId: selectedContinentId },
+        update(proxy) {
+            if (selectedContinentId) {
+                const data = proxy.readQuery({
+                    query: GET_CONTINENTS
+                });
+                data.getContinents = data.getContinents.filter(continent => continent.id !== selectedContinentId)
+                proxy.writeQuery({
+                    query: GET_CONTINENTS,
+                    data
+                })
+            }
+            if (callBack) {
+                callBack()
+            }
+        },
+        onError(err) {
+            console.log(err)
+        }
+    })
+
+    return (
+        <>
+            <Tooltip title="Delete">
+
+                <IconButton onClick={handleClickOpen} >
+                    <DeleteIcon style={{ color: "red" }} />
+                </IconButton>
+            </Tooltip>
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                PaperComponent={PaperComponent}
+                aria-labelledby="draggable-dialog-title"
+            >
+                <DialogTitle style={{ cursor: 'move' }} id="draggable-dialog-title">
+                    Delete
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Are you sure that you want to delete this data ?  
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button autoFocus onClick={handleClose}>
+                        Cancel
+                    </Button>
+                    <Button onClick={
+                        () => {
+                            selectedCountryId ? deleteCountry() : deleteContinent()
+                        }}>Delete</Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+}
+
+const DELETE_COUNTRY_MUTATION = gql`
+            mutation($countryId: ID!) {
+                deleteCountry(countryID: $countryId)
+    }
+            `
+const DELETE_COTINENT_MUTATION = gql`
+            mutation($continentId: ID!) {
+                deleteContinent(continentID: $continentId)
+    }
+            `
+
+const GET_COUNTRIES = gql`
+            query getCountries{
+                getCountries {
+                id
+            name
+            cases
+            todayCases
+            todayDeaths
+            deaths
+            population
+            continent
+            active
+            recovered
+            todayRecovered
+        }
+    }
+            `;
+const GET_CONTINENTS = gql`
+            query getContinents{
+                getContinents {
+                id
+            name
+            cases
+            todayCases
+            todayDeaths
+            deaths
+            population
+            active
+            recovered
+            todayRecovered
+        }
+    }
+            `;
+
+export default DeleteButton;
+

--- a/client/src/components/MenuBar.js
+++ b/client/src/components/MenuBar.js
@@ -1,38 +1,30 @@
 import React, { useContext, useState } from 'react';
-import { Navbar, Container, Nav, NavDropdown } from 'react-bootstrap';
+import { Navbar, Container, Nav } from 'react-bootstrap';
 import HomeIcon from '@mui/icons-material/Home';
-import Avatar from '@mui/material/Avatar';
 import { AuthContext } from '../context/auth';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Paper from '@mui/material/Paper';
+import Draggable from 'react-draggable';
 
-function stringToColor(string) {
-    let hash = 0;
-    let i;
 
-    /* eslint-disable no-bitwise */
-    for (i = 0; i < string.length; i += 1) {
-        hash = string.charCodeAt(i) + ((hash << 5) - hash);
-    }
+import '../css/Home.css'
 
-    let color = '#';
 
-    for (i = 0; i < 3; i += 1) {
-        const value = (hash >> (i * 8)) & 0xff;
-        color += `00${value.toString(16)}`.substr(-2);
-    }
-    /* eslint-enable no-bitwise */
-
-    return color;
-}
-
-function stringAvatar(name) {
-    return {
-        sx: {
-            bgcolor: stringToColor(name),
-        },
-        children: `${name.split(' ')[0][0]}${name.split(' ')[1][0]}`,
-    };
+function PaperComponent(props) {
+    return (
+        <Draggable
+            handle="#draggable-dialog-title"
+            cancel={'[class*="MuiDialogContent-root"]'}
+        >
+            <Paper {...props} />
+        </Draggable>
+    );
 }
 
 
@@ -51,7 +43,15 @@ const MenuBar = () => {
         }
     })
     const classes = useStyles()
+    const [open, setOpen] = useState(false);
 
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
     const { user, logout } = useContext(AuthContext)
     const menuBar = user ? (<div className='container mb-5'>
         <Navbar collapseOnSelect expand="lg" bg="light" variant="light" fixed="top">
@@ -69,21 +69,57 @@ const MenuBar = () => {
                 <Navbar.Toggle aria-controls="responsive-navbar-nav" />
                 <Navbar.Collapse id="responsive-navbar-nav">
                     <Nav className="me-auto ">
+                        <Nav.Link href="/"><HomeIcon /></Nav.Link>
                     </Nav>
+
                     <Nav>
-                    </Nav>
-                    <Nav>
-                        <Nav.Link href='/'>
-                            <Avatar sx={{ bgcolor: '#21ABAB' }} >
-                                {user.username[0]}
-                            </Avatar>
+                        {/* if the user is an admin then show a Admin tap 
+                        tp show all the users writes to the database  */}
+                        {user.type === "Admin" ? (
+                            <Nav.Link href="/admin">
+                                <Button className={classes.button} color='success' variant="contained" size="small" >
+                                    Admin
+                                </Button>
+                            </Nav.Link>
+                        ) : ''}
+                        <Nav.Link href='/continent'>
+                            <Button className={classes.button} color='success' variant="contained" size="small" >
+                                Continent
+                            </Button>
+                        </Nav.Link>
+                        <Nav.Link href='/country'>
+                            <Button className={classes.button} color='success' variant="contained" size="small" >
+                                Country
+                            </Button>
+                        </Nav.Link>
+                        <Nav.Link onClick={handleClickOpen}>
+                            <Button className={classes.button} color='success' variant="contained" size="small" >
+                                Log out
+                            </Button>
+                            <Dialog
+                                open={open}
+                                onClose={handleClose}
+                                PaperComponent={PaperComponent}
+                                aria-labelledby="draggable-dialog-title"
+                            >
+                                <DialogTitle style={{ cursor: 'move' }} id="draggable-dialog-title">
+                                    Subscribe
+                                </DialogTitle>
+                                <DialogContent>
+                                    <DialogContentText>
+                                        Are you sure you want to Logout 
+                                    </DialogContentText>
+                                </DialogContent>
+                                <DialogActions>
+                                    <Button autoFocus onClick={handleClose}>
+                                        Cancel
+                                    </Button>
+                                    <Button onClick={logout}>Logout</Button>
+                                </DialogActions>
+                            </Dialog>
                         </Nav.Link>
                     </Nav>
 
-                    <Nav.Link onClick={logout}>
-                        <Button className={classes.button} color='success' variant="contained" size="small" >
-                            Log out
-                        </Button></Nav.Link>
                 </Navbar.Collapse>
             </Container>
         </Navbar>

--- a/client/src/css/Home.css
+++ b/client/src/css/Home.css
@@ -12,7 +12,7 @@
 }
 
 .cases-header {
-    font-size: x-large; 
+    font-size: x-large;
     font-family: 'Quicksand', sans-serif;
     text-align: center;
     font-weight: 600;

--- a/client/src/css/Profile.css
+++ b/client/src/css/Profile.css
@@ -14,11 +14,18 @@
 }
 
 .content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
     font-family: 'Quicksand', sans-serif;
     text-align: center;
     font-size: 30px;
     font-weight: bold;
     color: rgb(114, 113, 113);
+}
+.content > div {
+    margin: 5px 5px 5px 5px;
 }
 
 
@@ -28,4 +35,37 @@
     font-size: 30px;
     font-weight: bold;
     margin-top: 120px;
+}
+
+.user-info {
+    font-family: 'Quicksand', sans-serif;
+    border-style: solid;
+    border-color: #21ABAB;
+    padding: 4px 4px 4px 4px;
+    border-radius: 20px;
+    background-color: aliceblue;
+}
+
+.user-info>div {
+    color: #21ABAB;
+    font-weight: 500;
+    margin-bottom: 0px;
+}
+
+.red-info {
+    font-family: 'Quicksand', sans-serif;
+    color: tomato;
+}
+
+.normal-info {
+    font-family: 'Quicksand', sans-serif;
+    color: #21ABAB;
+}
+
+.table-title {
+    font-family: 'Quicksand', sans-serif;
+    font-size: 40px;
+    text-align: center;
+    font-weight: bolder;
+    color: #21ABAB
 }

--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -1,0 +1,174 @@
+import React, { useEffect, useState, useContext } from 'react'
+import { useNavigate } from 'react-router-dom';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+import { AuthContext } from '../context/auth';
+import Home from './Home';
+import DeleteButton from '../components/DeleteButton';
+
+import { Container } from 'react-bootstrap';
+
+import Grow from '@mui/material/Grow';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+
+const Admin = (props) => {
+    const navigate = useNavigate();
+    const { user } = useContext(AuthContext)
+    const [slidePage, setSlidePage] = useState(false);
+    //get all the countries & continents from the database (two queries calls) 
+    const {
+        data
+    } = useQuery(GET_COUNTRIES_CONTINENTS);
+
+    function deleteCountryCallBack() {
+        navigate('/admin')
+    }
+
+    useEffect(() => {
+        setSlidePage(true)
+    }, [])
+    const adminPage = user && user.type === "Admin" ? (
+        <Grow
+            in={slidePage}
+            style={{ transformOrigin: '0 0 0' }}
+            {...(slidePage ? { timeout: 2000 } : {})}   >
+            <Container style={{ paddingTop: 40, b: 1, borderRadius: "50px", fontFamily: "Quicksand", marginBottom: "20px" }}>
+                <h1 className='table-title'>
+                    Countries
+                </h1>
+                <TableContainer component={Paper} style={{ marginTop: "50px", b: 1, borderRadius: "20px" }}>
+                    <Table sx={{ minWidth: 650 }} aria-label="simple table" >
+                        <caption>COVID-19 data for all countries saved in the database  </caption>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell style={{ color: "#21ABAB" }}>Name</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Continent</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Population</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Cases</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Deaths</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Recovered</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Active</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Cases</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Deaths</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Recovered</TableCell>
+                                <TableCell ></TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {data ?
+                                data.getCountries.map((country) => (
+                                    <TableRow
+                                        key={country.id}
+                                        sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                                    >
+                                        <TableCell style={{ color: "#21ABAB", fontWeight: "bold", fontSize: "18px" }}>{country.name}</TableCell>
+                                        <TableCell style={{ color: "#21ABAB", textAlign: "center" }}>{country.continent}</TableCell>
+                                        <TableCell style={{ textAlign: "center" }}>{country.population}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{country.cases}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{country.deaths}</TableCell>
+                                        <TableCell style={{ color: "#32CD32", textAlign: "center" }}>{country.recovered}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{country.active}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{country.todayCases}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{country.todayDeaths}</TableCell>
+                                        <TableCell style={{ color: "#32CD32", textAlign: "center" }}>{country.todayRecovered}</TableCell>
+                                        <TableCell>
+                                            <DeleteButton selectedCountryId={country.id} callBack={deleteCountryCallBack} />
+                                        </TableCell>
+                                    </TableRow>
+                                )) : (<TableRow><TableCell></TableCell></TableRow>)}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+                <h1 className='table-title mt-5'>
+                    Continents
+                </h1>
+                <TableContainer component={Paper} style={{ marginTop: "50px", b: 1, borderRadius: "20px" }}>
+                    <Table sx={{ minWidth: 650 }} aria-label="simple table" >
+                        <caption>COVID-19 data for all continents saved in the database </caption>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell style={{ color: "#21ABAB" }}>Name</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Population</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Cases</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Deaths</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Recovered</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Active</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Cases</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Deaths</TableCell>
+                                <TableCell style={{ color: "#21ABAB" }}>Today Recovered</TableCell>
+                                <TableCell ></TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {data ?
+                                data.getContinents.map((continent) => (
+                                    <TableRow
+                                        key={continent.id}
+                                        sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                                    >
+                                        <TableCell style={{ color: "#21ABAB", fontWeight: "bold", fontSize: "18px" }}>{continent.name}</TableCell>
+                                        <TableCell style={{ textAlign: "center" }}>{continent.population}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{continent.cases}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{continent.deaths}</TableCell>
+                                        <TableCell style={{ color: "#32CD32", textAlign: "center" }}>{continent.recovered}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{continent.active}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{continent.todayCases}</TableCell>
+                                        <TableCell style={{ color: "red", textAlign: "center" }}>{continent.todayDeaths}</TableCell>
+                                        <TableCell style={{ color: "#32CD32", textAlign: "center" }}>{continent.todayRecovered}</TableCell>
+                                        <TableCell>
+                                            <DeleteButton selectedContinentId={continent.id} callBack={deleteCountryCallBack} />
+
+                                        </TableCell>
+                                    </TableRow>
+                                )) : (<TableRow><TableCell></TableCell></TableRow>)}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Container >
+        </Grow>
+    ) : (
+        <Home />
+    )
+    return adminPage;
+}
+
+const GET_COUNTRIES_CONTINENTS = gql`
+    query {
+        getCountries {
+            id
+            name
+            cases
+            todayCases
+            todayDeaths
+            deaths
+            population
+            continent
+            active
+            recovered
+            todayRecovered
+        }
+        getContinents {
+            id
+            name
+            cases
+            todayCases
+            todayDeaths
+            deaths
+            population
+            active
+            recovered
+            todayRecovered
+        }
+    }
+`;
+
+
+
+export default Admin;

--- a/client/src/pages/Continent.js
+++ b/client/src/pages/Continent.js
@@ -71,7 +71,7 @@ function Continent(props) {
         setSuccessful(false)
         try {
 
-            const response = await fetch(`https://disease.sh/v3/covid-19/continents/${continent}?yesterday=yesterday&strict=true`)
+            const response = await fetch(`https://disease.sh/v3/covid-19/continents/${continent}?yesterday=true&strict=true`)
             if (response.ok) {
                 setError(false)
                 const continent_obj = await response.json()
@@ -404,11 +404,11 @@ function Continent(props) {
                             </h1>
                             <div>
                                 <Doughnut data={{
-                                    labels: ['Total Cases', 'Total Recovered', 'Total Deaths'],
+                                    labels: ['Active', 'Total Recovered', 'Total Deaths'],
                                     datasets: [
                                         {
-                                            label: 'Total Cases',
-                                            data: [currContinent.cases, currContinent.recovered, currContinent.deaths],
+                                            label: 'Total',
+                                            data: [currContinent.active, currContinent.recovered, currContinent.deaths],
                                             backgroundColor: [
                                                 'rgb(255, 205, 86)',
                                                 'rgb(54, 162, 235)',

--- a/client/src/pages/Country.js
+++ b/client/src/pages/Country.js
@@ -100,7 +100,7 @@ function Country(props) {
         setOpen(false)
         setSuccessful(false)
         try {
-            const response = await fetch(`https://disease.sh/v3/covid-19/countries/${country}?yesterday=yesterday`)
+            const response = await fetch(`https://disease.sh/v3/covid-19/countries/${country}?yesterday=true&strict=true`)
             if (response.ok) {
                 setError(false)
                 const country_obj = await response.json()
@@ -329,7 +329,7 @@ function Country(props) {
                         </Col>
                     </Row>
                     <Row className='info-card shadow mt-5'>
-                        <Col className=' mt-5 mb-5 ' xs={12} md={6}>
+                        <Col className=' mt-5 mb-5 ' xs={12} md={4}>
                             <h2 className='country-info mt-4'>
                                 Tests
                                 <br />
@@ -338,7 +338,7 @@ function Country(props) {
                                 {currCountry.tests}
                             </h4>
                         </Col>
-                        <Col className=' mt-5 mb-5 ' xs={12} md={6}>
+                        <Col className=' mt-5 mb-5 ' xs={12} md={4}>
                             <h2 className='country-info mt-4'>
                                 Critical
                                 <br />
@@ -347,14 +347,18 @@ function Country(props) {
                                 {currCountry.critical}
                             </h4>
                         </Col>
+                        <Col className=' mt-5 mb-5 ' xs={12} md={4}>
+                            <h2 className='country-info mt-4'>
+                                Active
+                                <br />
+                            </h2>
+                            <h4 className="total-deaths mt-4">
+                                {currCountry.active}
+                            </h4>
+                        </Col>
                     </Row>
                     <Row>
                         <Col className='mt-5 mb-5' xs={12} md={6}>
-                            {/* <div>{`value: ${value !== null ? `'${value}'` : 'null'}`}</div>
-                            <div>{`inputValue: '${inputValue}'`}</div> */}
-                            <h1 className='total-header mb-3 '>
-                                Today Stats
-                            </h1>
                             <div>
                                 <Doughnut data={{
                                     labels: ['Today Cases', 'Today Recovered', 'Today Deaths'],
@@ -379,16 +383,14 @@ function Country(props) {
                             </div>
                         </Col>
                         <Col className='mt-5' xs={12} md={6}>
-                            <h1 className='total-header mb-3'>
-                                Total Stats
-                            </h1>
+                            
                             <div>
                                 <Doughnut data={{
-                                    labels: ['Total Cases', 'Total Recovered', 'Total Deaths'],
+                                    labels: ['Active', 'Total Recovered', 'Total Deaths'],
                                     datasets: [
                                         {
-                                            label: 'Total Cases',
-                                            data: [currCountry.cases, currCountry.recovered, currCountry.deaths],
+                                            label: 'Total',
+                                            data: [currCountry.active, currCountry.recovered, currCountry.deaths],
                                             backgroundColor: [
                                                 'rgb(255, 205, 86)',
                                                 'rgb(54, 162, 235)',
@@ -408,7 +410,7 @@ function Country(props) {
                     </Row>
                     <Row className='info-card shadow mt-5'>
                         <Col>
-                            <h1 className='total-header mt-5 mb-5'>
+                            <h1 className='total-header mt-3 mb-3'>
                                 {currCountry.country}'s Location <LocationOnIcon style={{ marginTop: -12, fontSize: 45, color: "#21ABAB" }} />
                             </h1>
                             <MapContainer

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -55,7 +55,7 @@ function Login() {
                 <br />
                 <br />
                 <br />
-                <Row className='shadow-lg p-3 mb-5 bg-white'>
+                <Row className='shadow-lg p-3 mb-5 bg-white' style={{ borderRadius: "30px" }}>
                     <Col className="mt-3" md={5} xs={12}>
                         <form onSubmit={onSubmit} noValidate>
                             <h3 className='text-center mb-4'>Log In</h3>
@@ -122,7 +122,7 @@ const LOGIN_USER = gql`
             username: $username
             password: $password
         ){
-            id email username createdAt token
+            id email username createdAt type token
         }
     }
 `

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { AuthContext } from '../context/auth';
 import Button from '@mui/material/Button';
@@ -9,9 +9,19 @@ import MapChart from '../components/MapChart';
 import ReactTooltip from "react-tooltip";
 import Zoom from '@mui/material/Zoom';
 import Grow from '@mui/material/Grow';
+import Box from '@mui/material/Box';
+import Popper from '@mui/material/Popper';
+import Fade from '@mui/material/Fade';
+import Chip from '@mui/material/Chip';
+
 import { makeStyles } from '@material-ui/core/styles';
 
 import '../css/Profile.css'
+
+import PersonIcon from '@mui/icons-material/Person';
+import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import DateRangeIcon from '@mui/icons-material/DateRange';
 
 function Profile(props) {
     const useStyles = makeStyles({
@@ -31,7 +41,18 @@ function Profile(props) {
     const [zoom, setZoom] = useState(false)
     const [slidePage, setSlidePage] = useState(false)
     const [content, setContent] = useState("");
-    // fetch the country list from the react-select-country-list library
+
+    const [open, setOpen] = useState(false);
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+        setOpen((previousOpen) => !previousOpen);
+    };
+
+    const canBeOpen = open && Boolean(anchorEl);
+    const id = canBeOpen ? 'transition-popper' : undefined;
+
     const classes = useStyles()
 
     useEffect(() => {
@@ -47,8 +68,41 @@ function Profile(props) {
                 <Row className='mt-5'>
                     <Col className='mt-5'>
                         <h4 className='welcome-message mt-5'>
-                            Welcome {user.username}  !
+                            Welcome <Chip label={user.username} variant="outlined" onClick={handleClick} sx={{ marginBottom: 0.5 }} />
+                            &nbsp;!
                         </h4>
+                        <Popper id={id} open={open} anchorEl={anchorEl} transition>
+                            {({ TransitionProps }) => (
+                                <Fade {...TransitionProps} timeout={350}>
+                                    <Box className='user-info'>
+                                        <div>
+                                            <PersonIcon style={{ fontSize: 20 }} /> Username:
+                                            <p style={{ color: "black", fontWeight: 700, marginBottom: 0 }}>
+                                                {user.username}
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <AlternateEmailIcon style={{ fontSize: 20 }} /> Email:
+                                            <p style={{ color: "black", fontWeight: 700, marginBottom: 0 }}>
+                                                {user.email}
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <AdminPanelSettingsIcon style={{ fontSize: 20 }} /> Type:
+                                            <p style={{ color: "black", fontWeight: 700, marginBottom: 0 }}>
+                                                {user.type ? user.type : ''}
+                                            </p>
+                                        </div>
+                                        <div>
+                                            <DateRangeIcon style={{ fontSize: 20 }} /> Joined:
+                                            <p style={{ color: "black", fontWeight: 700, marginBottom: 0 }}>
+                                                {user.createdAt ? user.createdAt.slice(0, 10) : ''}
+                                            </p>
+                                        </div>
+                                    </Box>
+                                </Fade>
+                            )}
+                        </Popper>
                         <h1 className='content-header mt-3 '>
                             COVID-19 Data <CoronavirusIcon style={{ fontSize: 70 }} />
                         </h1>
@@ -56,18 +110,22 @@ function Profile(props) {
                             Select whether you want the latest and total cases<br />from a country or continent
                         </div>
                         <div className='content mt-4'>
-                            <Zoom in={zoom}>
-                                <Button className={classes.button} color='success' variant="contained" href="/country" endIcon={<FlagIcon />} size="large" >
-                                    Country
-                                </Button>
-                            </Zoom>
-                            &nbsp;&nbsp;
-                            <Zoom in={zoom}>
-                                <Button className={classes.button} color='success' variant="contained" href="/continent" endIcon={<PublicIcon />} size="large">
-                                    Continente
-                                </Button>
-                            </Zoom>
+                            <div>
+                                <Zoom in={zoom}>
+                                    <Button className={classes.button} color='success' variant="contained" href="/country" endIcon={<FlagIcon />} size="large" >
+                                        Country
+                                    </Button>
+                                </Zoom>
+                            </div>
+                            
+                            <div>
+                                <Zoom in={zoom}>
+                                    <Button className={classes.button} color='success' variant="contained" href="/continent" endIcon={<PublicIcon />} size="large">
+                                        Continente
+                                    </Button>
+                                </Zoom>
 
+                            </div>
 
                         </div>
                         <div className=''>

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -12,7 +12,10 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
 import Backdrop from '@mui/material/Backdrop';
-
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
 import '../css/Register.css';
 
 function Register(props) {
@@ -24,7 +27,8 @@ function Register(props) {
         username: '',
         email: '',
         password: '',
-        confirmPassword: ''
+        confirmPassword: '',
+        type: ''
     })
     const [open, setOpen] = useState(false);
     const onChange = (event) => {
@@ -53,11 +57,11 @@ function Register(props) {
     }, [])
     return (
         <Slide direction="up" in={slidePage} mountOnEnter unmountOnExit timeout={1000}>
-            <Container className='mt-5' fluid='xxl'>
+            <Container className='mt-5' fluid='xxl' >
                 <br />
                 <br />
                 <br />
-                <Row className='shadow-lg p-3 mb-5 bg-white rounded'>
+                <Row className='shadow-lg p-3 mb-5 bg-white' style={{ borderRadius: "30px" }}>
                     <Col className="mt-3 mb-3" md={5} xs={12}>
                         <form onSubmit={onSubmit} className={loading ? 'loading' : ''} noValidate>
 
@@ -102,7 +106,6 @@ function Register(props) {
                                     value={values.password}
                                     onChange={onChange}
                                     error={errors.password ? true : false}
-                                    helperText={errors.password ? "Incorrect Password." : ""}
                                     fullWidth
                                 />
                             </div>
@@ -116,11 +119,29 @@ function Register(props) {
                                     autoComplete="current-password"
                                     value={values.confirmPassword}
                                     error={errors.confirmPassword ? true : false}
-                                    helperText={errors.password ? "Incorrect Password." : ""}
                                     onChange={onChange}
                                     fullWidth
                                 />
                             </div>
+                            <FormLabel component="legend">User Type</FormLabel>
+                            <RadioGroup row aria-label="user" name="row-radio-buttons-group">
+                                <FormControlLabel
+                                    id="userType"
+                                    name='type'
+                                    value="User"
+                                    control={<Radio />}
+                                    label="User"
+                                    onChange={onChange}
+                                />
+                                <FormControlLabel
+                                    id="adminType"
+                                    name='type'
+                                    value="Admin"
+                                    control={<Radio />}
+                                    label="Admin"
+                                    onChange={onChange}
+                                />
+                            </RadioGroup>
                             <Button type='submit' color="inherit" variant="contained" size="medium" fullWidth> {
                                 loading ? (<CircularProgress />) : (<LoginIcon />)
                             }
@@ -159,6 +180,7 @@ const REGISTER_USER = gql`
         $email: String!
         $password: String!
         $confirmPassword: String!
+        $type: String!
     ) {
         register(
             registerInput: {
@@ -166,9 +188,10 @@ const REGISTER_USER = gql`
                 email: $email
                 password: $password
                 confirmPassword: $confirmPassword
+                type: $type
             }
         ){
-            id email username createdAt token
+            id email username createdAt type token
         }
     }
 `

--- a/client/src/util/AdminRoute.js
+++ b/client/src/util/AdminRoute.js
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { AuthContext } from '../context/auth';
+
+function AdminRoute({ children }) {
+    const { user } = useContext(AuthContext);
+
+    return !user || user.type !== "Admin"
+        ? <Navigate to="/" replace />
+        : children;
+}
+
+export default AdminRoute;

--- a/client/src/util/DataRoute.js
+++ b/client/src/util/DataRoute.js
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { AuthContext } from '../context/auth';
+
+function DataRoute({ children }) {
+    const { user } = useContext(AuthContext);
+
+    return !user
+        ? <Navigate to="/" replace />
+        : children;
+}
+
+export default DataRoute;

--- a/graphql/resolvers/users.js
+++ b/graphql/resolvers/users.js
@@ -14,13 +14,15 @@ const User = require('../../models/User');
 var strongRegex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})");
 var mediumRegex = new RegExp("^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})");
 
+// TODO : add admin prop to the user input 
 
 function generateToken(user) {
     return jwt.sign(
         {
             id: user.id,
             email: user.email,
-            username: user.username
+            username: user.username,
+            type: user.type
         },
         SECRET_KEY,
         { expiresIn: '1h' }
@@ -70,7 +72,7 @@ module.exports = {
         async register(
             _,
             {
-                registerInput: { username, email, password, confirmPassword }
+                registerInput: { username, email, password, confirmPassword, type }
             }
         ) {
             // Validate user data
@@ -78,7 +80,8 @@ module.exports = {
                 username,
                 email,
                 password,
-                confirmPassword
+                confirmPassword,
+                type
             );
             if (!valid) {
                 throw new UserInputError('Errors', { errors });
@@ -105,7 +108,8 @@ module.exports = {
                 email,
                 username,
                 password,
-                createdAt: new Date().toISOString()
+                createdAt: new Date().toISOString(),
+                type
             });
 
             const res = await newUser.save();

--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -32,12 +32,14 @@ module.exports = gql`
     token: String!
     username: String!
     createdAt: String!
+    type: String!
   }
   input RegisterInput {
     username: String!
     password: String!
     confirmPassword: String!
     email: String!
+    type: String!
   }
   input CountryInput {
     name: String!

--- a/models/User.js
+++ b/models/User.js
@@ -1,8 +1,11 @@
 const { model, Schema } = require('mongoose')
+// TODO : add admin prop
 const userSchema = new Schema({
     username: String,
     password: String,
     email: String,
-    createdAt: String
+    createdAt: String,
+    type: String // = User -> normal user 
+                 // = Admin -> Same as normal user but with the ability to see all the writes to the database 
 });
 module.exports = model('User', userSchema)

--- a/util/validators.js
+++ b/util/validators.js
@@ -2,7 +2,8 @@ module.exports.validateRegisterInput = (
     username,
     email,
     password,
-    confirmPassword
+    confirmPassword,
+    type
 ) => {
     const errors = {};
     if (username.trim() === '') {
@@ -21,7 +22,9 @@ module.exports.validateRegisterInput = (
     } else if (password !== confirmPassword) {
         errors.confirmPassword = 'Passwords must match';
     }
-
+    if (type !== 'User' && type !== 'Admin' ) {
+        errors.type = 'Type must be : User or Admin';
+    }
     return {
         errors,
         valid: Object.keys(errors).length < 1


### PR DESCRIPTION
- Added a new prop to the user: **`type`** 
     - the user can be a normal user or an admin
     - the admin can access and modify the saved data in the database
- The user can choose which type of user he is on the register page 
- Updated the app bar so it will show the admin page option if the user is an admin  
- The admin option takes the user to a new page that will show all the saved COVID-19 data (countries & continents) as tables.
- Each row in the table shows the data about the country or continent, and at the end of the row, there is a delete button the admin can choose to delete the data from the database. 
- The delete button is a new component that will call a mutation call to delete the data, it will refresh the page after the delete to show that the selected data is gone. 
- Added two new routes to make sure that the country & continent and admin pages can't be accessed if the user isn't logged in.
     - if the user tries so, the server rerenders him to the homepage.
-  Added the country and continents option to the app bar 
-  Removed unused imports. 